### PR TITLE
fixed toString return type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -308,6 +308,9 @@ export class TinyColor {
    *
    * @param format - The format to be used when displaying the string representation.
    */
+  toString<T extends ColorFormats>(): string;
+  toString<T extends 'name'>(format: T): boolean | string;
+  toString<T extends ColorFormats>(format: T): string;
   toString(format?: ColorFormats): string | false {
     const formatSet = Boolean(format);
     format = format ?? this.format;


### PR DESCRIPTION
fixes toString return type:

```js
const value1: string = new TinyColor('#ccc').toString();
const value2: string = new TinyColor('#ccc').toString('rgb);
const value3: string | boolean = new TinyColor('#ccc').toString('name');
```
