### PR TITLE
fix: narrow toString return type if passed format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -308,6 +308,8 @@ export class TinyColor {
    *
    * @param format - The format to be used when displaying the string representation.
    */
+  toString<T extends 'name'>(format: T): boolean | string;
+  toString<T extends ColorFormats>(format?: T): string;
   toString(format?: ColorFormats): string | false {
     const formatSet = Boolean(format);
     format = format ?? this.format;
@@ -371,7 +373,7 @@ export class TinyColor {
   }
 
   clone(): TinyColor {
-    return new TinyColor(this.toString() as string);
+    return new TinyColor(this.toString());
   }
 
   /**


### PR DESCRIPTION
fixes toString return type:

```js
const value1: string = new TinyColor('#ccc').toString();
const value2: string = new TinyColor('#ccc').toString('rgb');
const value3: string | boolean = new TinyColor('#ccc').toString('name');
```
