### PR TITLE
feat: export conversion functions

### DIFF
--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -7,6 +7,7 @@ export * from './from-ratio';
 export * from './format-input';
 export * from './random';
 export * from './interfaces';
+export * from './conversion';
 
 // kept for backwards compatability with v1
 export default tinycolor;

--- a/tsconfig.module.json
+++ b/tsconfig.module.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "module": "esnext",
-    "declaration": true,
+    "declaration": false,
     "outDir": "dist/module",
     "skipLibCheck": true
   },

--- a/tsconfig.module.json
+++ b/tsconfig.module.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.build.json",
   "compilerOptions": {
     "module": "esnext",
-    "declaration": false,
+    "declaration": true,
     "outDir": "dist/module",
     "skipLibCheck": true
   },


### PR DESCRIPTION
When I want to use tinycolor in a treeshakable manner, dts file is required for module imports.

The `TinyColor` from index is still too large.

Related messaage: https://github.com/ant-design/ant-design-colors/pull/74

https://github.com/ant-design/ant-design-colors/pull/74/files#diff-32637e146b1570a9bf3c528dfa96ff3fb136f95135645dd152667ad057639b1c