### PR TITLE
doc: random `seed` should not be a string

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ You can pass an options object to influence the type of color it produces. The o
 * `hue` – Controls the hue of the generated color. You can pass a string representing a color name: `red`, `orange`, `yellow`, `green`, `blue`, `purple`, `pink` and `monochrome` are currently supported. If you pass a hexidecimal color string such as #00FFFF, its hue value will be extracted and used to generate colors.
 * `luminosity` – Controls the luminosity of the generated color. You can specify a string containing bright, light or dark.
 * `count` – An integer which specifies the number of colors to generate.
-* `seed` – An integer or string which when passed will cause randomColor to return the same color each time.
+* `seed` – An integer which when passed will cause randomColor to return the same color each time.
 * `alpha` – A decimal between 0 and 1. Only relevant when using a format with an alpha channel (rgba and hsla). Defaults to a random value.
 
 ```ts


### PR DESCRIPTION
There is a misdescription in the readme.

Btw, are we able to support string input? We might need something like this though https://github.com/davidmerfield/randomColor/blob/master/randomColor.js#L460-L467