### PR TITLE
feat: Add isMonochrome() method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -164,6 +164,14 @@ export class TinyColor {
   }
 
   /**
+   * Returns whether the color is monochrome.
+   */
+  isMonochrome(): boolean {
+    const { s } = this.toHsl();
+    return s === 0;
+  }
+
+  /**
    * Returns the object as a HSVA object.
    */
   toHsv(): Numberify<HSVA> {


### PR DESCRIPTION
I quite often need a check whether a color is monochrome, so I thought, why not share this `isMonochrome()` method with the community. Some people might find this useful too.