### PR TITLE
fix: onBackground() should composite alpha channel correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -552,11 +552,13 @@ export class TinyColor {
   onBackground(background: ColorInput): TinyColor {
     const fg = this.toRgb();
     const bg = new TinyColor(background).toRgb();
+    const alpha = fg.a + bg.a * (1 - fg.a);
 
     return new TinyColor({
-      r: bg.r + (fg.r - bg.r) * fg.a,
-      g: bg.g + (fg.g - bg.g) * fg.a,
-      b: bg.b + (fg.b - bg.b) * fg.a,
+      r: (fg.r * fg.a + bg.r * bg.a * (1 - fg.a)) / alpha,
+      g: (fg.g * fg.a + bg.g * bg.a * (1 - fg.a)) / alpha,
+      b: (fg.b * fg.a + bg.b * bg.a * (1 - fg.a)) / alpha,
+      a: alpha,
     });
   }
 

--- a/test/conversions.spec.ts
+++ b/test/conversions.spec.ts
@@ -111,4 +111,13 @@ describe('TinyColor Conversions', () => {
       expect(tiny.toHexString()).toBe(new TinyColor(tiny).toHexString());
     }
   });
+  it('Alpha compositing correctly', () => {
+    const tiny1 = new TinyColor('rgba(255,0,0,0.5)');
+    const tiny2 = new TinyColor('rgba(0,255,0,0.5)');
+    const tiny3 = new TinyColor('rgba(0,0,255,1)');
+    const tiny4 = new TinyColor('rgba(0,0,0,0.5)');
+    expect(tiny1.onBackground(tiny2).toRgbString()).toBe('rgba(170, 85, 0, 0.75)');
+    expect(tiny1.onBackground(tiny3).toRgbString()).toBe('rgb(128, 0, 128)');
+    expect(tiny3.onBackground(tiny4).toRgbString()).toBe('rgb(0, 0, 255)');
+  });
 });


### PR DESCRIPTION
This fix resolves two semi-transparent colors incorrect alpha channel result when using onBackground function.
FYI: [Alpha_compositing](https://en.wikipedia.org/wiki/Alpha_compositing)