### PR TITLE
perf: optimize isValidCSSUnit

### DIFF
--- a/src/format-input.ts
+++ b/src/format-input.ts
@@ -217,5 +217,9 @@ export function stringInputToObject(color: string): any {
  * (see `matchers` above for definition).
  */
 export function isValidCSSUnit(color: string | number): boolean {
-  return Boolean(matchers.CSS_UNIT.exec(String(color)));
+  if (typeof color === 'number') {
+    return !Number.isNaN(color);
+  }
+
+  return matchers.CSS_UNIT.test(color);
 }


### PR DESCRIPTION
This PR introduces a fast-path for numbers passed to `isValidCSSUnit`, and avoids `Boolean()`/`String()` casting.

From what I can tell, numbers cast as strings always pass the `CSS_UNIT` regex (except for `NaN`), so we can skip the regex for numbers. And it looks like numbers are often the input too.

---

In a [project](https://github.com/withastro/docs) I'm testing, 

before:

<img width="628" alt="image" src="https://github.com/scttcper/tinycolor/assets/34116392/dc75799b-0ec1-47d0-91fb-e4b33c8317f2">

after: 

<img width="628" alt="image" src="https://github.com/scttcper/tinycolor/assets/34116392/017265ac-98ee-4f35-b797-fbc556031f59">

Looks like strings aren't used in the project I'm testing, so the regex is avoided altogether. Bringing the execution time of `isValidCSSUnit` from 1.11s to 0.0002s.