### PR TITLE
fix: replaced link to color conversion reference

### DIFF
--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -2,7 +2,7 @@ import { HSL, HSV, Numberify, RGB } from './interfaces.js';
 import { bound01, pad2 } from './util.js';
 
 // `rgbToHsl`, `rgbToHsv`, `hslToRgb`, `hsvToRgb` modified from:
-// <http://mjijackson.com/2008/02/rgb-to-hsl-and-rgb-to-hsv-color-model-conversion-algorithms-in-javascript>
+// <https://gist.github.com/mjackson/5311256>
 
 /**
  * Handle bounds / percentage checking to conform to CSS color spec


### PR DESCRIPTION
Outdated link to original reference blog post now points to an "illegal website." Updated to point to a gist from the original author.

Issue reference: https://github.com/scttcper/tinycolor/issues/255

Link has been updated to: https://gist.github.com/mjackson/5311256

fixes #255